### PR TITLE
Fix dependency and manual parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,12 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "libarchive-wasm": "^0.2.0",
+    "libarchive-wasm": "^1.2.0",
     "jszip": "^3.10.0",
     "@chakra-ui/react": "^2.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "framer-motion": "^10.18.0",
-    "docker-url-parser": "^1.0.2",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,13 +2,12 @@ lockfileVersion: '6.0'
 settings:
   packageManager: 'pnpm@9.0.0'
 specifiers:
-  libarchive-wasm: ^0.2.0
+  libarchive-wasm: ^1.2.0
   jszip: ^3.10.0
   '@chakra-ui/react': ^2.8.1
   '@emotion/react': ^11.11.1
   '@emotion/styled': ^11.11.0
   framer-motion: ^10.18.0
-  docker-url-parser: ^1.0.2
   react: ^18.3.0
   react-dom: ^18.3.0
   astro: ^4.0.0

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -31,7 +31,7 @@ function parseImageRef(ref: string) {
     throw new Error(`Digests are not supported in image references: '${ref}'`);
   }
   if (remainder.includes(':')) {
-    [remainder, tag] = remainder.split(':');
+    [remainder, tag] = remainder.split(':', 2);
   }
 
   const parts = remainder.split('/');

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -28,7 +28,7 @@ function parseImageRef(ref: string) {
 
   let tag: string | undefined;
   if (remainder.includes('@')) {
-    [remainder] = remainder.split('@');
+    throw new Error(`Digests are not supported in image references: '${ref}'`);
   }
   if (remainder.includes(':')) {
     [remainder, tag] = remainder.split(':');


### PR DESCRIPTION
## Summary
- remove dependency on `docker-url-parser`
- implement a lightweight image reference parser in `registry.ts`
- update `libarchive-wasm` to `^1.2.0`

## Testing
- `pnpm install` *(fails: registry access blocked)*
- `pnpm build` *(fails: astro not found because dependencies weren't installed)*


------
https://chatgpt.com/codex/tasks/task_e_685e0402d9e0832d8f173232aaddedfa